### PR TITLE
Converted About Bar into Footer

### DIFF
--- a/src/main/webapp/electionlist.html
+++ b/src/main/webapp/electionlist.html
@@ -16,162 +16,161 @@
     <script src="script.js"></script>
   </head>
   <body>
-    <a href="index.html">
-      <div id="header-bar">
-        <p id="header-text">gVote</p>
+    <div id="page-wrapper">
+      <a href="index.html">
+        <div id="header-bar">
+          <p id="header-text">gVote</p>
+        </div>
+      </a>
+
+      <div class="container" id="content">
+        <div class="row page-title-text" id="dropdown-title">
+          <p class="col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2">
+            <b>To explore the upcoming elections you can vote in, select the state you live in:</b>
+          </p> 
+        </div>
+        <div class="row" id="state-dropdown">
+          <select id="select-state" name="states">
+            <option disabled selected><em>Please select a state</em></option>
+            <option value="state:ak">Alaska</option>
+            <option value="state:al">Alabama</option>
+            <option value="state:ar">Arkansas</option>
+            <option value="state:az">Arizona</option>
+            <option value="state:ca">California</option>
+            <option value="state:co">Colorado</option>
+            <option value="state:ct">Connecticut</option>
+            <option value="state:de">Delaware</option>
+            <option value="district:dc">District of Columbia</option>
+            <option value="state:fl">Florida</option>
+            <option value="state:ga">Georgia</option>
+            <option value="state:hi">Hawaii</option>
+            <option value="state:ia">Iowa</option>
+            <option value="state:id">Idaho</option>
+            <option value="state:il">Illinois</option>
+            <option value="state:in">Indiana</option>
+            <option value="state:ks">Kansas</option>
+            <option value="state:ky">Kentucky</option>
+            <option value="state:la">Louisiana</option>
+            <option value="state:ma">Massachusetts</option>
+            <option value="state:md">Maryland</option>
+            <option value="state:me">Maine</option>
+            <option value="state:mi">Michigan</option>
+            <option value="state:mn">Minnesota</option>
+            <option value="state:mo">Missouri</option>
+            <option value="state:ms">Mississippi</option>
+            <option value="state:mt">Montana</option>
+            <option value="state:nc">North Carolina</option>
+            <option value="state:nd">North Dakota</option>
+            <option value="state:ne">Nebraska</option>
+            <option value="state:nh">New Hampshire</option>
+            <option value="state:nj">New Jersey</option>
+            <option value="state:nm">New Mexico</option>
+            <option value="state:nv">Nevada</option>
+            <option value="state:ny">New York</option>
+            <option value="state:oh">Ohio</option>
+            <option value="state:ok">Oklahoma</option>
+            <option value="state:or">Oregon</option>
+            <option value="state:pa">Pennsylvania</option>
+            <option value="state:ri">Rhode Island</option>
+            <option value="state:sc">South Carolina</option>
+            <option value="state:sd">South Dakota</option>
+            <option value="state:tn">Tennessee</option>
+            <option value="state:tx">Texas</option>
+            <option value="state:ut">Utah</option>
+            <option value="state:va">Virginia</option>
+            <option value="state:vt">Vermont</option>
+            <option value="state:wa">Washington</option>
+            <option value="state:wi">Wisconsin</option>
+            <option value="state:wv">West Virginia</option>
+            <option value="state:wy">Wyoming</option> 
+          </select>
+        </div>
+        <div class="container-fluid" id="election-list-content">
+          <h3>Elections coming up in Washington</h3>
+          <ul class="list-group list-group-flush" id="election-list">
+            <li class="list-group-item" id="election-item">
+              <div class="election-quick-details">
+                <p>Washington State Primary Election</p>
+                <p><em>August 4, 2020</em></p>
+              </div>
+              <div class="learn-more-button">Learn more</div>
+            </li>
+            <li class="list-group-item" id="election-item">
+              <div class="election-quick-details">
+                <p>Other Election Title</p>
+                <p><em>August 40, 2020</em></p>
+              </div>
+              <div class="learn-more-button">Learn more</div>
+            </li>
+          </ul>
+          <h3>Elections coming up in the United States</h3>
+          <ul class="list-group list-group-flush" id="election-list">
+            <li class="list-group-item" id="election-item">
+              <div class="election-quick-details">
+                <p>Washington State Primary Election</p>
+                <p><em>August 4, 2020</em></p>
+              </div>
+              <div class="learn-more-button">Learn more</div>
+            </li>
+            <li class="list-group-item" id="election-item">
+              <div class="election-quick-details">
+                <p>Other Election Title</p>
+                <p><em>August 40, 2020</em></p>
+              </div>
+              <div class="learn-more-button">Learn more</div>
+            </li>
+          </ul>
+        </div>
+
       </div>
-    </a>
 
-    <div class="container" id="content">
-      <div class="row page-title-text" id="dropdown-title">
-        <p class="col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2">
-          <b>To explore the upcoming elections you can vote in, select the state you live in:</b>
-        </p> 
+
+      <div id="about-bar">
+        <div class="container" id="about-content">
+          <div class="row">
+            <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="find-elections-container">
+              <div class="image-wrapper">
+                <img src="icons/registerIcon.svg" class="icon" id="register-icon"/>
+              </div>
+              <div class="about-description">
+                <p class="description-heading">
+                  <b>Find Elections</b>
+                <p>
+                <p class="description-body">
+                  Find upcoming elections affecting your area by simply providing your address.
+                </p>
+              </div>  
+            </div>
+            <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="stay-informed-container">
+              <div class="image-wrapper">
+                <img src="icons/informIcon.svg" class="icon" id="register-icon"/>
+              </div>
+              <div class="about-description">
+                <p class="description-heading">
+                  <b>Stay Informed</b>
+                <p>
+                <p class="description-body">
+                  See what’s on the ballot for each election and get information and relevant links 
+                  for all positions, candidates, and propositions.
+                </p>
+              </div>  
+            </div>
+            <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="go-vote-container">
+              <div class="image-wrapper">
+                <img src="icons/mapIcon.svg" class="icon" id="register-icon"/>
+              </div>
+              <div class="about-description">
+                <p class="description-heading">
+                  <b>Go Vote</b>
+                <p>
+                <p class="description-body">Find polling places near your address along with mail-in 
+                  and in person voting deadlines for your area.
+                </p>
+              </div>  
+            </div>
+          </div>   
+        </div> 
       </div>
-      <div class="row" id="state-dropdown">
-        <select id="select-state" name="states">
-          <option disabled selected><em>Please select a state</em></option>
-          <option value="state:ak">Alaska</option>
-          <option value="state:al">Alabama</option>
-          <option value="state:ar">Arkansas</option>
-          <option value="state:az">Arizona</option>
-          <option value="state:ca">California</option>
-          <option value="state:co">Colorado</option>
-          <option value="state:ct">Connecticut</option>
-          <option value="state:de">Delaware</option>
-          <option value="district:dc">District of Columbia</option>
-          <option value="state:fl">Florida</option>
-          <option value="state:ga">Georgia</option>
-          <option value="state:hi">Hawaii</option>
-          <option value="state:ia">Iowa</option>
-          <option value="state:id">Idaho</option>
-          <option value="state:il">Illinois</option>
-          <option value="state:in">Indiana</option>
-          <option value="state:ks">Kansas</option>
-          <option value="state:ky">Kentucky</option>
-          <option value="state:la">Louisiana</option>
-          <option value="state:ma">Massachusetts</option>
-          <option value="state:md">Maryland</option>
-          <option value="state:me">Maine</option>
-          <option value="state:mi">Michigan</option>
-          <option value="state:mn">Minnesota</option>
-          <option value="state:mo">Missouri</option>
-          <option value="state:ms">Mississippi</option>
-          <option value="state:mt">Montana</option>
-          <option value="state:nc">North Carolina</option>
-          <option value="state:nd">North Dakota</option>
-          <option value="state:ne">Nebraska</option>
-          <option value="state:nh">New Hampshire</option>
-          <option value="state:nj">New Jersey</option>
-          <option value="state:nm">New Mexico</option>
-          <option value="state:nv">Nevada</option>
-          <option value="state:ny">New York</option>
-          <option value="state:oh">Ohio</option>
-          <option value="state:ok">Oklahoma</option>
-          <option value="state:or">Oregon</option>
-          <option value="state:pa">Pennsylvania</option>
-          <option value="state:ri">Rhode Island</option>
-          <option value="state:sc">South Carolina</option>
-          <option value="state:sd">South Dakota</option>
-          <option value="state:tn">Tennessee</option>
-          <option value="state:tx">Texas</option>
-          <option value="state:ut">Utah</option>
-          <option value="state:va">Virginia</option>
-          <option value="state:vt">Vermont</option>
-          <option value="state:wa">Washington</option>
-          <option value="state:wi">Wisconsin</option>
-          <option value="state:wv">West Virginia</option>
-          <option value="state:wy">Wyoming</option> 
-        </select>
-      </div>
-    </div>
-
-    <div class="container-fluid" id="election-list-content">
-      <h3>Elections coming up in Washington</h3>
-      <ul class="list-group list-group-flush" id="election-list">
-        <li class="list-group-item" id="election-item">
-          <div class="election-quick-details">
-            <p>Washington State Primary Election</p>
-            <p><em>August 4, 2020</em></p>
-          </div>
-          <div class="learn-more-button">Learn more</div>
-        </li>
-        <li class="list-group-item" id="election-item">
-          <div class="election-quick-details">
-            <p>Other Election Title</p>
-            <p><em>August 40, 2020</em></p>
-          </div>
-          <div class="learn-more-button">Learn more</div>
-        </li>
-      </ul>
-      <h3>Elections coming up in the United States</h3>
-      <ul class="list-group list-group-flush" id="election-list">
-        <li class="list-group-item" id="election-item">
-          <div class="election-quick-details">
-            <p>Washington State Primary Election</p>
-            <p><em>August 4, 2020</em></p>
-          </div>
-          <div class="learn-more-button">Learn more</div>
-        </li>
-        <li class="list-group-item" id="election-item">
-          <div class="election-quick-details">
-            <p>Other Election Title</p>
-            <p><em>August 40, 2020</em></p>
-          </div>
-          <div class="learn-more-button">Learn more</div>
-        </li>
-      </ul>
-    </div>
-
-    <div class="container-fluid" id="content-padding">
-      &nbsp;
-    </div>
-
-    <div id="about-bar">
-      <div class="container" id="about-content">
-        <div class="row">
-          <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="find-elections-container">
-            <div class="image-wrapper">
-              <img src="icons/registerIcon.svg" class="icon" id="register-icon"/>
-            </div>
-            <div class="about-description">
-              <p class="description-heading">
-                <b>Find Elections</b>
-              <p>
-              <p class="description-body">
-                Find upcoming elections affecting your area by simply providing your address.
-              </p>
-            </div>  
-          </div>
-          <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="stay-informed-container">
-            <div class="image-wrapper">
-              <img src="icons/informIcon.svg" class="icon" id="register-icon"/>
-            </div>
-            <div class="about-description">
-              <p class="description-heading">
-                <b>Stay Informed</b>
-              <p>
-              <p class="description-body">
-                See what’s on the ballot for each election and get information and relevant links 
-                for all positions, candidates, and propositions.
-              </p>
-            </div>  
-          </div>
-          <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="go-vote-container">
-            <div class="image-wrapper">
-              <img src="icons/mapIcon.svg" class="icon" id="register-icon"/>
-            </div>
-            <div class="about-description">
-              <p class="description-heading">
-                <b>Go Vote</b>
-              <p>
-              <p class="description-body">Find polling places near your address along with mail-in 
-                and in person voting deadlines for your area.
-              </p>
-            </div>  
-          </div>
-        </div>   
-      </div> 
     </div>
   </body>
 </html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -17,83 +17,85 @@
 
   </head>
   <body>
-    <a href="index.html">
-      <div id="header-bar">
-        <p id="header-text">gVote</p>
-      </div>
-    </a>
+    <div id="page-wrapper">
+      <a href="index.html">
+        <div id="header-bar">
+          <p id="header-text">gVote</p>
+        </div>
+      </a>
 
-    <div class="container" id="content">
-      <div class="row page-title-text">
-        <p class="col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2">
-          Hello! We’re gVote, and we want to help you learn <b>when and how to vote in the 
-          United States</b>. 
-          <br>
-          <br>
-          Before you continue: <b>are you registered to vote</b>?
-        </p> 
+      <div class="container" id="content">
+        <div class="row page-title-text">
+          <p class="col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2">
+            Hello! We’re gVote, and we want to help you learn <b>when and how to vote in the 
+            United States</b>. 
+            <br>
+            <br>
+            Before you continue: <b>are you registered to vote</b>?
+          </p> 
+        </div>
+        <div class="row" id="register-buttons">
+          <a href="https://turbovote.org/" target="_blank">
+            <div class="col-lg-3 col-lg-offset-2 col-md-3 col-md-offset-2 col-sm-3 col-sm-offset-2" 
+                 id="turbo-vote-button">
+              No, take me to TurboVote
+            </div>
+          </a>
+          <a href="electionlist.html">
+            <div class="col-lg-3 col-lg-offset-2 col-md-3 col-md-offset-2 col-sm-3 col-sm-offset-2" 
+                 id="show-elections-button">
+              Yes, show me my upcoming elections
+            </div>
+          </a>
+        </div> 
       </div>
-      <div class="row" id="register-buttons">
-        <a href="https://turbovote.org/" target="_blank">
-          <div class="col-lg-3 col-lg-offset-2 col-md-3 col-md-offset-2 col-sm-3 col-sm-offset-2" 
-               id="turbo-vote-button">
-            No, take me to TurboVote
-          </div>
-        </a>
-        <a href="electionlist.html">
-          <div class="col-lg-3 col-lg-offset-2 col-md-3 col-md-offset-2 col-sm-3 col-sm-offset-2" 
-               id="show-elections-button">
-            Yes, show me my upcoming elections
-          </div>
-        </a>
-      </div> 
-    </div>
-    
-    <div id="about-bar">
-      <div class="container" id="about-content">
-        <div class="row">
-          <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="find-elections-container">
-            <div class="image-wrapper">
-              <img src="icons/registerIcon.svg" class="icon" id="register-icon"/>
+      
+      <div id="about-bar">
+        <div class="container" id="about-content">
+          <div class="row">
+            <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="find-elections-container">
+              <div class="image-wrapper">
+                <img src="icons/registerIcon.svg" class="icon" id="register-icon"/>
+              </div>
+              <div class="about-description">
+                <p class="description-heading">
+                  <b>Find Elections</b>
+                <p>
+                <p class="description-body">
+                  Find upcoming elections affecting your area by simply providing your address.
+                </p>
+              </div>  
             </div>
-            <div class="about-description">
-              <p class="description-heading">
-                <b>Find Elections</b>
-              <p>
-              <p class="description-body">
-                Find upcoming elections affecting your area by simply providing your address.
-              </p>
-            </div>  
-          </div>
-          <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="stay-informed-container">
-            <div class="image-wrapper">
-              <img src="icons/informIcon.svg" class="icon" id="register-icon"/>
+            <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="stay-informed-container">
+              <div class="image-wrapper">
+                <img src="icons/informIcon.svg" class="icon" id="register-icon"/>
+              </div>
+              <div class="about-description">
+                <p class="description-heading">
+                  <b>Stay Informed</b>
+                <p>
+                <p class="description-body">
+                  See what’s on the ballot for each election and get information and relevant links 
+                  for all positions, candidates, and propositions.
+                </p>
+              </div>  
             </div>
-            <div class="about-description">
-              <p class="description-heading">
-                <b>Stay Informed</b>
-              <p>
-              <p class="description-body">
-                See what’s on the ballot for each election and get information and relevant links 
-                for all positions, candidates, and propositions.
-              </p>
-            </div>  
-          </div>
-          <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="go-vote-container">
-            <div class="image-wrapper">
-              <img src="icons/mapIcon.svg" class="icon" id="register-icon"/>
+            <div class = "col-lg-4 col-md-4 col-sm-4 about-info-container" id="go-vote-container">
+              <div class="image-wrapper">
+                <img src="icons/mapIcon.svg" class="icon" id="register-icon"/>
+              </div>
+              <div class="about-description">
+                <p class="description-heading">
+                  <b>Go Vote</b>
+                <p>
+                <p class="description-body">Find polling places near your address along with mail-in 
+                  and in person voting deadlines for your area.
+                </p>
+              </div>  
             </div>
-            <div class="about-description">
-              <p class="description-heading">
-                <b>Go Vote</b>
-              <p>
-              <p class="description-body">Find polling places near your address along with mail-in 
-                and in person voting deadlines for your area.
-              </p>
-            </div>  
-          </div>
-        </div>   
-      </div> 
+          </div>   
+        </div> 
+      </div>
     </div>
   </body>
 </html>

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -10,6 +10,11 @@ body{
   font-family: Nunito Sans;
 }
 
+#page-wrapper{
+  position: relative;
+  min-height: 100%;
+}
+
 #header-bar{
   position: fixed;
   width: 100%;
@@ -37,6 +42,7 @@ body{
 
 #content{
   width: 100%;
+  padding-bottom: 11%; 
 }
 
 .page-title-text p {
@@ -44,7 +50,7 @@ body{
   margin-top: 10%;
   font-style: normal;
   font-weight: normal;
-  font-size: 5vh;
+  font-size: 5vmin;
   line-height: 120%;
 }
 
@@ -53,11 +59,11 @@ body{
 }
 
 #register-buttons div{
-  min-height: 10vh;
+  min-height: 10vmin;
   height:auto;
   font-style: normal;
   font-weight: bold;
-  font-size: 3vh;
+  font-size: 3vmin;
   text-align: center;
   color: #FFFFFF;
   box-sizing: border-box;
@@ -94,16 +100,11 @@ body{
   color: #668EDB;
 }
 
-#content-padding{
-  width: 100%;
-  margin-bottom: 10%;
-}
 
 #about-bar{
-  position: fixed;
   width: 100%;
   min-height: 20%;
-  bottom: 0px;
+  bottom: 0;
   height: auto;
   background: #BED4FF;
 }
@@ -112,8 +113,8 @@ body{
   fill-opacity: 1;
   float: left;
   margin-right: 8%;
-  width:10vh;
-  height:10vh;
+  width:10vmin;
+  height:10vmin;
   padding-top: 2%;
   clear: both;
 }
@@ -138,14 +139,14 @@ body{
 .description-heading{
   font-style: normal;
   font-weight: bold;
-  font-size: 2vh;
+  font-size: 2vmin;
   overflow: hidden;
 }
 
 .description-body{
   font-style: normal;
   font-weight: normal;
-  font-size: 1.8vh;
+  font-size: 1.8vmin;
   overflow: hidden;
 }
 
@@ -158,15 +159,15 @@ body{
   display: flex;
   justify-content: center;
   align-content: center;
-  margin: 2vh 0;
+  margin: 2vmin 0;
 }
 
 #state-dropdown > select {
   background-color: #FFFFFF;
   border: 1px solid #C5C5C5;
   border-radius: 20px;
-  font-size: 2vh;
-  padding: 0.8vh 1vh;
+  font-size: 2vmin;
+  padding: 0.8vmin 1vmin;
   cursor: pointer;
   outline:none;
 }
@@ -188,7 +189,7 @@ body{
 }
 
 .election-quick-details p {
-  font-size: 2.5vh;
+  font-size: 2.5vmin;
 }
 
 .learn-more-button {


### PR DESCRIPTION
Converted the about bar from a fixed UI element to a footer. The most notable change is with the State Elections List page which now looks as follows:
![image](https://user-images.githubusercontent.com/41168973/88332725-fc017400-ccfc-11ea-8a73-134ff7ab150f.png)
with the user now having to scroll down to see the about bar. 

Another notable change is switching from using vh to vmin as sizing units in the style.css file to increase responsiveness to changing window sizes, specifically when the viewing window is more tall than wide.