### PR TITLE
Fix about-bar bug on Election list page

### DIFF
--- a/src/main/java/com/google/sps/servlets/ElectionServlet.java
+++ b/src/main/java/com/google/sps/servlets/ElectionServlet.java
@@ -62,4 +62,3 @@ public class ElectionServlet extends HttpServlet {
     response.getWriter().println(json);
   }
 }
-

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -12,8 +12,9 @@ body{
 }
 
 #page-wrapper{
-  position: relative;
-  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 #header-bar{
@@ -43,7 +44,8 @@ body{
 
 #content{
   width: 100%;
-  padding-bottom: 11%; 
+  flex: 1; 
+  padding-bottom: 5%;
 }
 
 .page-title-text p {
@@ -111,7 +113,6 @@ body{
 }
 
 .icon{
-  fill-opacity: 1;
   float: left;
   margin-right: 8%;
   width:10vmin;


### PR DESCRIPTION
Previously if there were no elections displayed on the Elections List page then the footer bar would float in the middle of the page but now it will always remain at the bottom of the page.