### PR TITLE
Add ChromeDriverPropertySetup test rule to set "webdriver.chrome.driver"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target/
+config.js
+.DS_Store
 
 # IntelliJ specific project files
 .idea/

--- a/src/test/java/com/google/sps/integration/ChromeDriverPropertySetup.java
+++ b/src/test/java/com/google/sps/integration/ChromeDriverPropertySetup.java
@@ -4,7 +4,10 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-/** Sets the "webdriver.chrome.driver" property to use the correct chromedriver binary depending on the os. */
+/**
+ * Sets the "webdriver.chrome.driver" property to use the correct chromedriver binary depending on
+ * the os.
+ */
 public class ChromeDriverPropertySetup implements TestRule {
   @Override
   public Statement apply(Statement statement, Description description) {

--- a/src/test/java/com/google/sps/integration/ChromeDriverPropertySetup.java
+++ b/src/test/java/com/google/sps/integration/ChromeDriverPropertySetup.java
@@ -1,0 +1,28 @@
+package com.google.sps.integration;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/** Sets the "webdriver.chrome.driver" property to use the correct chromedriver binary depending on the os. */
+public class ChromeDriverPropertySetup implements TestRule {
+  @Override
+  public Statement apply(Statement statement, Description description) {
+    System.out.println(System.getProperty("os.name").toLowerCase());
+    if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+      System.setProperty("webdriver.chrome.driver", "resources/chromedriver_mac");
+    } else {
+      System.setProperty("webdriver.chrome.driver", "resources/chromedriver");
+    }
+    try {
+      return new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+          statement.evaluate();
+        }
+      };
+    } finally {
+
+    }
+  }
+}

--- a/src/test/java/com/google/sps/integration/ElectionListIT.java
+++ b/src/test/java/com/google/sps/integration/ElectionListIT.java
@@ -1,10 +1,6 @@
 package com.google.sps.integration;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -14,10 +10,7 @@ import org.openqa.selenium.support.ui.Select;
 public class ElectionListIT {
   private WebDriver driver;
 
-  @BeforeClass
-  public static void setUp() {
-    System.setProperty("webdriver.chrome.driver", "resources/chromedriver");
-  }
+  @ClassRule public static ChromeDriverPropertySetup chromeDriverPropertySetup = new ChromeDriverPropertySetup();
 
   @Before
   public void testSetUp() {

--- a/src/test/java/com/google/sps/integration/ElectionListIT.java
+++ b/src/test/java/com/google/sps/integration/ElectionListIT.java
@@ -10,7 +10,9 @@ import org.openqa.selenium.support.ui.Select;
 public class ElectionListIT {
   private WebDriver driver;
 
-  @ClassRule public static ChromeDriverPropertySetup chromeDriverPropertySetup = new ChromeDriverPropertySetup();
+  @ClassRule
+  public static ChromeDriverPropertySetup chromeDriverPropertySetup =
+      new ChromeDriverPropertySetup();
 
   @Before
   public void testSetUp() {

--- a/src/test/java/com/google/sps/integration/WelcomePageIT.java
+++ b/src/test/java/com/google/sps/integration/WelcomePageIT.java
@@ -1,10 +1,6 @@
 package com.google.sps.integration;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -15,10 +11,7 @@ public class WelcomePageIT {
   private static final int WAIT_TIME = 30;
   private static final int MAX_NUM_TABS = 2;
 
-  @BeforeClass
-  public static void setUp() {
-    System.setProperty("webdriver.chrome.driver", "resources/chromedriver");
-  }
+  @ClassRule public static ChromeDriverPropertySetup chromeDriverPropertySetup = new ChromeDriverPropertySetup();
 
   @Before
   public void testSetUp() {

--- a/src/test/java/com/google/sps/integration/WelcomePageIT.java
+++ b/src/test/java/com/google/sps/integration/WelcomePageIT.java
@@ -11,7 +11,9 @@ public class WelcomePageIT {
   private static final int WAIT_TIME = 30;
   private static final int MAX_NUM_TABS = 2;
 
-  @ClassRule public static ChromeDriverPropertySetup chromeDriverPropertySetup = new ChromeDriverPropertySetup();
+  @ClassRule
+  public static ChromeDriverPropertySetup chromeDriverPropertySetup =
+      new ChromeDriverPropertySetup();
 
   @Before
   public void testSetUp() {


### PR DESCRIPTION
Add ChromeDriverPropertySetup test rule to set "webdriver.chrome.driver" property to the correct chromedriver binary depending on the os type.