### PR TITLE
Catch JSONException when referendumSubtitle does not exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,18 @@
       <version>1.9.81</version>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>

--- a/src/main/java/com/google/sps/data/Referendum.java
+++ b/src/main/java/com/google/sps/data/Referendum.java
@@ -49,9 +49,24 @@ public abstract class Referendum {
 
   // creates a new Referendum object by extracting the properties from "obj"
   public static Referendum fromJSONObject(JSONObject obj) throws JSONException {
+    String referendumDescription;
+    String referendumTitle;
+
+    try {
+      referendumTitle = obj.getString(TITLE_JSON_KEYWORD);
+    } catch (JSONException e) {
+      throw new JSONException("Referendum title not found in JSON response.");
+    }
+
+    try {
+      referendumDescription = obj.getString(DESCRIPTION_JSON_KEYWORD);
+    } catch (JSONException e) {
+      referendumDescription = "";
+    }
+
     return Referendum.builder()
-        .setTitle(obj.getString(TITLE_JSON_KEYWORD))
-        .setDescription(obj.getString(DESCRIPTION_JSON_KEYWORD))
+        .setTitle(referendumTitle)
+        .setDescription(referendumDescription)
         .build();
   }
 

--- a/src/main/java/com/google/sps/data/Referendum.java
+++ b/src/main/java/com/google/sps/data/Referendum.java
@@ -18,6 +18,8 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.Entity;
 import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -29,6 +31,8 @@ public abstract class Referendum {
   public static final String DESCRIPTION_JSON_KEYWORD = "referendumSubtitle";
   public static final String TITLE_ENTITY_KEYWORD = "title";
   public static final String DESCRIPTION_ENTITY_KEYWORD = "description";
+  public static final String SOURCE_CLASS = Referendum.class.getName();
+  public static final Logger LOGGER = Logger.getLogger(SOURCE_CLASS);
 
   public abstract String getTitle();
 
@@ -55,7 +59,8 @@ public abstract class Referendum {
     try {
       referendumTitle = obj.getString(TITLE_JSON_KEYWORD);
     } catch (JSONException e) {
-      throw new JSONException("Referendum title not found in JSON response.");
+      LOGGER.logp(Level.WARNING, SOURCE_CLASS, "fromJSONObject", "referendumTitle does not exist");
+      throw new JSONException("Malformed referendum JSONObject: referendumTitle does not exist.");
     }
 
     try {

--- a/src/test/java/com/google/sps/data/ReferendumTest.java
+++ b/src/test/java/com/google/sps/data/ReferendumTest.java
@@ -15,9 +15,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+@RunWith(JUnit4.class)
 public class ReferendumTest {
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(
@@ -70,7 +73,7 @@ public class ReferendumTest {
             "{\"type\": \"Referendum\", \"referendumSubtitle\": \"Water Bond. Funding for Water Quality, Supply, Treatment, and Storage Projects.\"}");
 
     exceptionRule.expect(JSONException.class);
-    exceptionRule.expectMessage("Referendum title not found in JSON response.");
+    exceptionRule.expectMessage("Malformed referendum JSONObject: referendumTitle does not exist.");
     Referendum referendum = Referendum.fromJSONObject(referendumJsonObject);
   }
 


### PR DESCRIPTION
Deployed site had issues where a 500 error was thrown when the referendumSubtitle field didn't exist since JSONObject.getString() threw an uncaught JSONException. Fixed issue by catching the JSONException and subsequently filling in the description field in Referendum with an empty string.